### PR TITLE
Fix: Useing correct SOAP type (ArrayOfstring with namespace) for GetEBillRecipientSubscriptionStatusBulk

### DIFF
--- a/ebilling_postfinance/ebilling_postfinance.py
+++ b/ebilling_postfinance/ebilling_postfinance.py
@@ -128,16 +128,14 @@ class WebService:
          recipient_id: a list of ebill recipient id, email address or UIDHR
 
         """
-        array_bill_recipient = self.client.get_type("ns2:ArrayOfBillRecipient")
+        array_bill_recipient = self.client.get_type(
+            '{http://schemas.microsoft.com/2003/10/Serialization/Arrays}ArrayOfstring'
+        )
         recipients = array_bill_recipient(bill_recipient_id)
 
         res = self.service.GetEBillRecipientSubscriptionStatusBulk(
             BillerID=self.biller_id, RecipientID=recipients
         )
-        # An error occurs, maybe because the response is badly formatted ?
-        # zeep.exceptions.ValidationError:
-        #     Missing element SubmissionStatus
-        #     (GetEBillRecipientSubscriptionStatusBulk.RecipientID.BillRecipient)
         return res
 
     def get_invoice_list(self, archive_data=False):


### PR DESCRIPTION
This PR fixes an issue in the `get_ebill_recipient_subscription_status_bulk` method.

The method was using an incorrect SOAP type (`ns2:ArrayOfBillRecipient`) to serialize the list of recipient IDs. This caused the request to only send the first ID in the list, which in turn often led to a `zeep.exceptions.ValidationError` when parsing the single-item response.

This commit updates the `client.get_type` call to use the correct `ArrayOfstring` type with its full namespace, as identified from the raw SOAP logs:
`{http://schemas.microsoft.com/2003/10/Serialization/Arrays}ArrayOfstring`

This ensures all recipient IDs are correctly sent in the bulk request.